### PR TITLE
Apply iPL_2.4.32-ipod2_loader2_cmdline_support.patch

### DIFF
--- a/arch/armnommu/mach-ipod/arch.c
+++ b/arch/armnommu/mach-ipod/arch.c
@@ -18,10 +18,42 @@
 #include <asm/arch/irq.h>
 #include <asm/mach/arch.h>
 
+static short calc_checksum2 (char* dest, int size) {
+  short csum = 0;
+  while (size-- > 0) {
+    char b = *dest++;
+    csum = ((csum << 1) & 0xffff) + ((csum<0)? 1 : 0) + b;
+  }
+  return csum;
+}
+
+static char* getArgs (char* baseAddr) {
+  // fetch the args
+  if (strncmp (baseAddr, "Args", 4) == 0) {
+    int strlen = *(short*)(baseAddr+6);
+    if (*(short*)(baseAddr+4) == calc_checksum2 (baseAddr+6, strlen+2)) {
+      return baseAddr + 8;
+    }
+  }
+  return 0;
+}
+
+static char cmdlineBuffer[256] = "";
+
 static void __init
 ipod_fixup(struct machine_desc *desc, struct param_struct *params,
 	char **cmdline, struct meminfo *mi)
-{
+{	
+  char *args = getArgs (0x80);
+  if (args) {
+    if (*cmdline && **cmdline) {
+      // there is a default cmdline - copy it first, then append the args
+      strncat (cmdlineBuffer, *cmdline, sizeof(cmdlineBuffer)-1);
+      strncat (cmdlineBuffer, " ", sizeof(cmdlineBuffer)-1);
+    }
+    strncat (cmdlineBuffer, args, sizeof(cmdlineBuffer)-1);
+    *cmdline = cmdlineBuffer;
+  }
 }
 
 MACHINE_START(IPOD, "iPod")


### PR DESCRIPTION
Applies the iPL_2.4.32-ipod2_loader2_cmdline_support.patch which allows loader2 to pass kernel arguments to the kernel.

Successfully built with the arm-uclinux-elf-tools 3.4.3 toolchain on Debian 10 32 bit.

Tested on an iPod mini 2g and Loader2 v2.6.

`root=/dev/hda2` parameter was successfully passed to the kernel (and it instead complained about lack of init, as expected 😁)
`root=/dev/hda3` parameter was passed as a control, and it complains about unable to mount rootfs (again, as expected).